### PR TITLE
Added rememberSaveable support to StackNavHost and TabNavHost

### DIFF
--- a/lib/src/main/java/compass/stack/StackNavHost.kt
+++ b/lib/src/main/java/compass/stack/StackNavHost.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.*
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
@@ -117,7 +118,7 @@ private fun PageStack(
     modifier: Modifier = Modifier,
 ) {
     val transition = updateTransition(backStack, label = "Page Stack Transition")
-
+    val saveableStateHolder = rememberSaveableStateHolder()
     Box(modifier = modifier) {
         // bottom entry
         transition.AnimatedContent(
@@ -134,7 +135,9 @@ private fun PageStack(
                 check(it.entries.size > 1) { "First item in the stack can't be transparent" }
 
                 val bottomEntry = it.entries[it.entries.size - 2]
-                bottomEntry.Render(graph)
+                saveableStateHolder.SaveableStateProvider(key = bottomEntry.id) {
+                    bottomEntry.Render(graph)
+                }
             }
         }
 
@@ -161,7 +164,12 @@ private fun PageStack(
                 enter with exit
             }
         ) {
-            it.entries.lastOrNull()?.Render(graph)
+            val topEntry = it.entries.lastOrNull()
+            if (topEntry != null) {
+                saveableStateHolder.SaveableStateProvider(key = topEntry.id) {
+                    topEntry.Render(graph)
+                }
+            }
         }
     }
 }

--- a/lib/src/main/java/compass/tab/TabNavHost.kt
+++ b/lib/src/main/java/compass/tab/TabNavHost.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveableStateHolder
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.*
 import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
@@ -120,7 +121,7 @@ private fun TabStack(
     modifier: Modifier = Modifier,
 ) {
     val transition = updateTransition(backStack, label = "Tab Stack Transition")
-
+    val saveableStateHolder = rememberSaveableStateHolder()
     Box(modifier = modifier) {
         transition.AnimatedContent(
             transitionSpec = {
@@ -144,7 +145,12 @@ private fun TabStack(
                 }
             }
         ) {
-            it.entries.lastOrNull()?.Render(graph)
+            val entry = it.entries.lastOrNull()
+            if (entry != null) {
+                saveableStateHolder.SaveableStateProvider(key = entry.id) {
+                    entry.Render(graph)
+                }
+            }
         }
     }
 }

--- a/sample/src/main/java/compass/navigation/HomeUI.kt
+++ b/sample/src/main/java/compass/navigation/HomeUI.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import compass.navigation.common.Counter
 import kotlin.math.roundToInt
 
 @Composable
@@ -75,6 +76,9 @@ private fun FeedTitle() {
 @Composable
 fun HomeFeed() {
     LazyColumn(modifier = Modifier.fillMaxSize()) {
+        item {
+            Counter()
+        }
         items(100, key = { it }) {
             HomeFeedItem(it + 1)
             Spacer(Modifier.height(16.dp))

--- a/sample/src/main/java/compass/navigation/MainActivity.kt
+++ b/sample/src/main/java/compass/navigation/MainActivity.kt
@@ -24,7 +24,7 @@ class MainActivity : ComponentActivity(){
             CompassTheme {
                 // A surface container using the 'background' color from the theme
                 Surface(color = MaterialTheme.colors.background) {
-                    Sample2()
+                    App()
                 }
             }
         }

--- a/sample/src/main/java/compass/navigation/MainActivity.kt
+++ b/sample/src/main/java/compass/navigation/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.animation.ExperimentalAnimationApi
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -15,6 +16,7 @@ import compass.navigation.ui.theme.CompassTheme
 class MainActivity : ComponentActivity(){
     private var rootNavController: NavController? = null
 
+    @ExperimentalFoundationApi
     @ExperimentalAnimationApi
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -22,7 +24,7 @@ class MainActivity : ComponentActivity(){
             CompassTheme {
                 // A surface container using the 'background' color from the theme
                 Surface(color = MaterialTheme.colors.background) {
-                    App()
+                    Sample2()
                 }
             }
         }

--- a/sample/src/main/java/compass/navigation/Sample2.kt
+++ b/sample/src/main/java/compass/navigation/Sample2.kt
@@ -1,0 +1,33 @@
+package compass.navigation
+
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import compass.Page
+import compass.getNavController
+import compass.navigation.common.BigColumn
+import compass.navigation.common.Counter
+import compass.stack.StackNavHost
+
+@Composable
+fun Sample2() {
+    val navController = getNavController()
+    StackNavHost(navController = navController, startDestination = Page("A")) {
+        page("A") {
+            BigColumn(color = Color.Red) {
+                Counter()
+
+                Button(onClick = { navController.navigateTo("B") }) {
+                    Text(text = "GO TO B")
+                }
+            }
+        }
+
+        page("B") {
+            BigColumn(color = Color.Green) {
+                Counter()
+            }
+        }
+    }
+}

--- a/sample/src/main/java/compass/navigation/common/BigColumn.kt
+++ b/sample/src/main/java/compass/navigation/common/BigColumn.kt
@@ -1,0 +1,26 @@
+package compass.navigation.common
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+@Composable
+fun BigColumn(
+    color: Color,
+    content: @Composable () -> Unit
+) {
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(color),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        content()
+    }
+}

--- a/sample/src/main/java/compass/navigation/common/Counter.kt
+++ b/sample/src/main/java/compass/navigation/common/Counter.kt
@@ -1,0 +1,34 @@
+package compass.navigation.common
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun Counter() {
+    var count by rememberSaveable { mutableStateOf(0) }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        // Decrement
+        Button(onClick = { count-- }) {
+            Text(text = "-")
+        }
+        // Text
+        Text(text = "$count", modifier = Modifier.padding(horizontal = 10.dp))
+        // Increment
+        Button(onClick = { count++ }) {
+            Text(text = "+")
+        }
+    }
+}


### PR DESCRIPTION
# Summary

Previously, `rememberSaveable` wasn't considered when restoring the navEntry. This PR will implement `rememberSaveableStateHolder` inside `StackNavHost` to restore whatever state stored using `rememberSaveable`. As the `key`, we're using `NavEntry#id`

## Demo : `StackNavHost`

https://user-images.githubusercontent.com/9678279/130765224-11b2b1dd-5392-4887-bb36-adca8234dcbf.mp4

## Demo : `TabNavHost`


https://user-images.githubusercontent.com/9678279/130774442-200c89c5-ff8b-43c6-8c90-694843ad3d5f.mp4

